### PR TITLE
Support teachers with multiple classes

### DIFF
--- a/backend/controllers/teacherController.js
+++ b/backend/controllers/teacherController.js
@@ -2,7 +2,15 @@ const Teacher = require('../models/Teacher');
 
 exports.createTeacher = async (req, res) => {
   try {
-    const teacher = new Teacher(req.body);
+    const { classes, ...data } = req.body;
+    const teacher = new Teacher(data);
+
+    if (Array.isArray(classes) && classes.length > 0) {
+      teacher.classes = classes;
+      if (!teacher.grade && classes[0].grade) teacher.grade = classes[0].grade;
+      if (!teacher.subject && classes[0].subject) teacher.subject = classes[0].subject;
+    }
+
     await teacher.save();
     res.status(201).json({ teacher });
   } catch (err) {
@@ -13,9 +21,21 @@ exports.createTeacher = async (req, res) => {
 
 exports.getTeachers = async (req, res) => {
   try {
+    const { grade, subject } = req.query;
     const query = {};
-    if (req.query.grade) query.grade = parseInt(req.query.grade, 10);
-    if (req.query.subject) query.subject = req.query.subject;
+
+    if (grade && subject) {
+      const g = parseInt(grade, 10);
+      query.$or = [
+        { grade: g, subject },
+        { classes: { $elemMatch: { grade: g, subject } } }
+      ];
+    } else if (grade) {
+      const g = parseInt(grade, 10);
+      query.$or = [{ grade: g }, { 'classes.grade': g }];
+    } else if (subject) {
+      query.$or = [{ subject }, { 'classes.subject': subject }];
+    }
 
     const teachers = await Teacher.find(query).sort({ createdAt: -1 });
     res.json({ teachers });
@@ -38,7 +58,18 @@ exports.getTeacherById = async (req, res) => {
 
 exports.updateTeacher = async (req, res) => {
   try {
-    const teacher = await Teacher.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true });
+    const { classes, ...data } = req.body;
+
+    if (Array.isArray(classes) && classes.length > 0) {
+      data.classes = classes;
+      if (!data.grade && classes[0].grade) data.grade = classes[0].grade;
+      if (!data.subject && classes[0].subject) data.subject = classes[0].subject;
+    }
+
+    const teacher = await Teacher.findByIdAndUpdate(req.params.id, data, {
+      new: true,
+      runValidators: true
+    });
     if (!teacher) return res.status(404).json({ message: 'Teacher not found' });
     res.json({ teacher });
   } catch (err) {
@@ -65,8 +96,22 @@ exports.getAvailableSubjects = async (req, res) => {
     if (!grade) {
       return res.status(400).json({ message: 'Grade is required' });
     }
-    const subjects = await Teacher.find({ grade }).distinct('subject');
-    res.json({ subjects });
+
+    const teachers = await Teacher.find({
+      $or: [{ grade }, { 'classes.grade': grade }]
+    });
+
+    const subjectSet = new Set();
+    teachers.forEach((t) => {
+      if (t.grade === grade && t.subject) subjectSet.add(t.subject);
+      if (Array.isArray(t.classes)) {
+        t.classes.forEach((c) => {
+          if (c.grade === grade && c.subject) subjectSet.add(c.subject);
+        });
+      }
+    });
+
+    res.json({ subjects: Array.from(subjectSet) });
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Failed to fetch subjects' });

--- a/backend/models/Teacher.js
+++ b/backend/models/Teacher.js
@@ -1,13 +1,22 @@
 const mongoose = require('mongoose');
 
-const teacherSchema = new mongoose.Schema({
-  firstName: { type: String, required: true },
-  lastName: { type: String, required: true },
-  grade: { type: Number },
-  subject: { type: String, required: true },
-  email: { type: String },
-  phoneNumber: { type: String },
-  description: { type: String }
-}, { timestamps: true });
+const teacherSchema = new mongoose.Schema(
+  {
+    firstName: { type: String, required: true },
+    lastName: { type: String, required: true },
+    grade: { type: Number },
+    subject: { type: String },
+    email: { type: String },
+    phoneNumber: { type: String },
+    description: { type: String },
+    classes: [
+      {
+        grade: { type: Number, required: true },
+        subject: { type: String, required: true }
+      }
+    ]
+  },
+  { timestamps: true }
+);
 
 module.exports = mongoose.model('Teacher', teacherSchema);

--- a/frontend/src/pages/Admin/CreateTeacher.jsx
+++ b/frontend/src/pages/Admin/CreateTeacher.jsx
@@ -8,10 +8,9 @@ function CreateTeacher() {
     lastName: '',
     email: '',
     phoneNumber: '',
-    description: '',
-    grade: '',
-    subject: ''
+    description: ''
   });
+  const [classes, setClasses] = useState([{ grade: '', subject: '' }]);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
@@ -19,10 +18,26 @@ function CreateTeacher() {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
+  const handleClassChange = (index, field, value) => {
+    const updated = classes.map((cls, i) =>
+      i === index ? { ...cls, [field]: value } : cls
+    );
+    setClasses(updated);
+  };
+
+  const addClass = () => setClasses([...classes, { grade: '', subject: '' }]);
+  const removeClass = (index) =>
+    setClasses(classes.filter((_, i) => i !== index));
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await api.post('/teachers', form);
+      const payload = { ...form, classes };
+      if (classes[0]) {
+        payload.grade = classes[0].grade;
+        payload.subject = classes[0].subject;
+      }
+      await api.post('/teachers', payload);
       setMessage('Teacher created');
       navigate('/admin/teachers');
     } catch (err) {
@@ -39,20 +54,47 @@ function CreateTeacher() {
         <input className="form-control mb-2" name="lastName" placeholder="Last Name" value={form.lastName} onChange={handleChange} required />
         <input className="form-control mb-2" name="email" placeholder="Email" value={form.email} onChange={handleChange} />
         <input className="form-control mb-2" name="phoneNumber" placeholder="Phone" value={form.phoneNumber} onChange={handleChange} />
-        <select className="form-control mb-2" name="grade" value={form.grade} onChange={handleChange} required>
-          <option value="">Select Grade</option>
-          {[...Array(13)].map((_, i) => (
-            <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
-          ))}
-        </select>
-        <input
-          className="form-control mb-2"
-          name="subject"
-          placeholder="Subject"
-          value={form.subject}
-          onChange={handleChange}
-          required
-        />
+
+        {classes.map((cls, idx) => (
+          <div key={idx} className="d-flex mb-2 align-items-center">
+            <select
+              className="form-control me-2"
+              value={cls.grade}
+              onChange={(e) => handleClassChange(idx, 'grade', e.target.value)}
+              required
+            >
+              <option value="">Select Grade</option>
+              {[...Array(13)].map((_, i) => (
+                <option key={i + 1} value={i + 1}>
+                  Grade {i + 1}
+                </option>
+              ))}
+            </select>
+            <input
+              className="form-control me-2"
+              placeholder="Subject"
+              value={cls.subject}
+              onChange={(e) => handleClassChange(idx, 'subject', e.target.value)}
+              required
+            />
+            {classes.length > 1 && (
+              <button
+                type="button"
+                className="btn btn-danger btn-sm"
+                onClick={() => removeClass(idx)}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        <button
+          type="button"
+          className="btn btn-secondary mb-2"
+          onClick={addClass}
+        >
+          Add Class
+        </button>
         <textarea className="form-control mb-2" name="description" placeholder="Description" value={form.description} onChange={handleChange} />
         <button className="btn btn-primary">Create</button>
       </form>

--- a/frontend/src/pages/Admin/EditTeacher.jsx
+++ b/frontend/src/pages/Admin/EditTeacher.jsx
@@ -9,16 +9,30 @@ function EditTeacher() {
     lastName: '',
     email: '',
     phoneNumber: '',
-    description: '',
-    grade: '',
-    subject: ''
+    description: ''
   });
+  const [classes, setClasses] = useState([{ grade: '', subject: '' }]);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
   useEffect(() => {
-    api.get(`/teachers/${teacherId}`)
-      .then(res => setForm(res.data.teacher))
+    api
+      .get(`/teachers/${teacherId}`)
+      .then((res) => {
+        const t = res.data.teacher;
+        setForm({
+          firstName: t.firstName,
+          lastName: t.lastName,
+          email: t.email,
+          phoneNumber: t.phoneNumber,
+          description: t.description || ''
+        });
+        if (Array.isArray(t.classes) && t.classes.length > 0) {
+          setClasses(t.classes);
+        } else {
+          setClasses([{ grade: t.grade || '', subject: t.subject || '' }]);
+        }
+      })
       .catch(() => navigate('/admin/teachers'));
   }, [teacherId, navigate]);
 
@@ -26,10 +40,26 @@ function EditTeacher() {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
+  const handleClassChange = (index, field, value) => {
+    const updated = classes.map((cls, i) =>
+      i === index ? { ...cls, [field]: value } : cls
+    );
+    setClasses(updated);
+  };
+
+  const addClass = () => setClasses([...classes, { grade: '', subject: '' }]);
+  const removeClass = (index) =>
+    setClasses(classes.filter((_, i) => i !== index));
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await api.put(`/teachers/${teacherId}`, form);
+      const payload = { ...form, classes };
+      if (classes[0]) {
+        payload.grade = classes[0].grade;
+        payload.subject = classes[0].subject;
+      }
+      await api.put(`/teachers/${teacherId}`, payload);
       setMessage('Teacher updated');
       navigate('/admin/teachers');
     } catch (err) {
@@ -46,20 +76,43 @@ function EditTeacher() {
         <input className="form-control mb-2" name="lastName" placeholder="Last Name" value={form.lastName} onChange={handleChange} required />
         <input className="form-control mb-2" name="email" placeholder="Email" value={form.email} onChange={handleChange} />
         <input className="form-control mb-2" name="phoneNumber" placeholder="Phone" value={form.phoneNumber} onChange={handleChange} />
-        <select className="form-control mb-2" name="grade" value={form.grade} onChange={handleChange} required>
-          <option value="">Select Grade</option>
-          {[...Array(13)].map((_, i) => (
-            <option key={i + 1} value={i + 1}>Grade {i + 1}</option>
-          ))}
-        </select>
-        <input
-          className="form-control mb-2"
-          name="subject"
-          placeholder="Subject"
-          value={form.subject}
-          onChange={handleChange}
-          required
-        />
+
+        {classes.map((cls, idx) => (
+          <div key={idx} className="d-flex mb-2 align-items-center">
+            <select
+              className="form-control me-2"
+              value={cls.grade}
+              onChange={(e) => handleClassChange(idx, 'grade', e.target.value)}
+              required
+            >
+              <option value="">Select Grade</option>
+              {[...Array(13)].map((_, i) => (
+                <option key={i + 1} value={i + 1}>
+                  Grade {i + 1}
+                </option>
+              ))}
+            </select>
+            <input
+              className="form-control me-2"
+              placeholder="Subject"
+              value={cls.subject}
+              onChange={(e) => handleClassChange(idx, 'subject', e.target.value)}
+              required
+            />
+            {classes.length > 1 && (
+              <button
+                type="button"
+                className="btn btn-danger btn-sm"
+                onClick={() => removeClass(idx)}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        ))}
+        <button type="button" className="btn btn-secondary mb-2" onClick={addClass}>
+          Add Class
+        </button>
         <textarea className="form-control mb-2" name="description" placeholder="Description" value={form.description} onChange={handleChange} />
         <button className="btn btn-primary">Save</button>
       </form>

--- a/frontend/src/pages/Admin/TeacherList.jsx
+++ b/frontend/src/pages/Admin/TeacherList.jsx
@@ -37,13 +37,21 @@ function TeacherList() {
   };
 
   const getUniqueGrades = () => {
-    const grades = teachers.map(t => t.grade).filter(Boolean);
-    return [...new Set(grades)].sort((a, b) => a - b);
+    const gradeSet = new Set();
+    teachers.forEach((t) => {
+      if (t.grade) gradeSet.add(t.grade);
+      t.classes?.forEach((c) => c.grade && gradeSet.add(c.grade));
+    });
+    return Array.from(gradeSet).sort((a, b) => a - b);
   };
 
   const getUniqueSubjects = () => {
-    const subjects = teachers.map(t => t.subject).filter(Boolean);
-    return [...new Set(subjects)].sort();
+    const subjSet = new Set();
+    teachers.forEach((t) => {
+      if (t.subject) subjSet.add(t.subject);
+      t.classes?.forEach((c) => c.subject && subjSet.add(c.subject));
+    });
+    return Array.from(subjSet).sort();
   };
 
   const filteredAndSortedTeachers = () => {
@@ -54,8 +62,14 @@ function TeacherList() {
         teacher.subject?.toLowerCase().includes(searchTerm.toLowerCase()) ||
         teacher.email?.toLowerCase().includes(searchTerm.toLowerCase());
       
-      const matchesGrade = !filterGrade || teacher.grade?.toString() === filterGrade;
-      const matchesSubject = !filterSubject || teacher.subject === filterSubject;
+      const matchesGrade =
+        !filterGrade ||
+        teacher.grade?.toString() === filterGrade ||
+        teacher.classes?.some((c) => c.grade?.toString() === filterGrade);
+      const matchesSubject =
+        !filterSubject ||
+        teacher.subject === filterSubject ||
+        teacher.classes?.some((c) => c.subject === filterSubject);
       
       return matchesSearch && matchesGrade && matchesSubject;
     });
@@ -281,19 +295,17 @@ function TeacherList() {
                   </h3>
                   
                   <div className="teacher-details">
-                    {teacher.subject && (
-                      <div className="detail-item">
-                        <span className="detail-icon">📚</span>
-                        <span className="detail-text">{teacher.subject}</span>
-                      </div>
-                    )}
-                    
-                    {teacher.grade && (
-                      <div className="detail-item">
+                    {(teacher.classes && teacher.classes.length > 0
+                      ? teacher.classes
+                      : [{ grade: teacher.grade, subject: teacher.subject }]
+                    ).map((c, idx) => (
+                      <div className="detail-item" key={idx}>
                         <span className="detail-icon">🎓</span>
-                        <span className="detail-text">Grade {teacher.grade}</span>
+                        <span className="detail-text">
+                          Grade {c.grade} - {c.subject}
+                        </span>
                       </div>
-                    )}
+                    ))}
                     
                     {teacher.email && (
                       <div className="detail-item">


### PR DESCRIPTION
## Summary
- let teachers have a list of `classes` in the schema
- update teacher controller to store/update/search through classes
- allow admin to assign multiple classes to a teacher from the UI
- display all teacher classes in the admin list

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm run lint --prefix frontend` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686910ab29e08322bd030e39c6abe854