### PR TITLE
Add dedicated class dashboard

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ import Attendance from './pages/Dashboard/Attendance';
 import PaymentHistory from './pages/Dashboard/PaymentHistory';
 import PendingPayments from './pages/Dashboard/PendingPayments';
 import Notices from './pages/Dashboard/Notices';
+import ClassDashboard from './pages/Dashboard/ClassDashboard';
 import ELibrary from './pages/ELibrary/ELibrary';
 import PaymentSuccess from './pages/PaymentSuccess';
 
@@ -84,6 +85,7 @@ function App() {
         {/* Dashboard */}
         <Route path="/dashboard" element={<StudentDashboard />} />
         <Route path="/dashboard/classes" element={<MyClasses />} />
+        <Route path="/dashboard/course/:classId" element={<ClassDashboard />} />
         <Route path="/dashboard/recordings" element={<MyRecordings />} />
         <Route path="/dashboard/assignments" element={<MyAssignments />} />
         <Route path="/dashboard/notices" element={<Notices />} />

--- a/frontend/src/pages/Dashboard/ClassDashboard.jsx
+++ b/frontend/src/pages/Dashboard/ClassDashboard.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import api from '../../api';
+import Tile from '../../components/Tile';
+import './dashboard.css';
+
+const ClassDashboard = () => {
+  const { classId } = useParams();
+  const [course, setCourse] = useState(null);
+
+  useEffect(() => {
+    api.get(`/courses/${classId}`)
+      .then(res => setCourse(res.data.course))
+      .catch(() => setCourse(null));
+  }, [classId]);
+
+  return (
+    <div className="container py-5">
+      <div className="hero dashboard-hero mb-4">
+        <h2 className="mb-3">{course ? course.title : 'Class'}</h2>
+        {course?.description && (
+          <p className="mb-0">{course.description}</p>
+        )}
+      </div>
+      <div className="text-center mb-4">
+        <h4 className="fw-semibold">Class Links</h4>
+      </div>
+      <div className="row gy-4 dashboard-tiles">
+        <Tile title="Recordings" icon="🎥" link={`/dashboard/recordings/${classId}`} />
+        <Tile title="Assignments" icon="📝" link={`/dashboard/assignments/${classId}`} />
+        <Tile title="Notices" icon="📢" link="/dashboard/notices" />
+      </div>
+    </div>
+  );
+};
+
+export default ClassDashboard;

--- a/frontend/src/pages/Dashboard/MyClasses.jsx
+++ b/frontend/src/pages/Dashboard/MyClasses.jsx
@@ -376,7 +376,7 @@ const MyClasses = () => {
                     </div>
                     
                     <Link
-                      to={`/dashboard/recordings/${cls._id}`}
+                      to={`/dashboard/course/${cls._id}`}
                       className={`enter-button ${status === 'expired' ? 'disabled' : ''}`}
                       onClick={(e) => status === 'expired' && e.preventDefault()}
                     >


### PR DESCRIPTION
## Summary
- add `ClassDashboard` page to choose between recordings, assignments and notices
- update MyClasses to link to new class dashboard
- register new route in `App.jsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722c343b7c8322a03fa304730879f1