### PR TITLE
Add teacher login + assignment upload

### DIFF
--- a/backend/controllers/assignmentController.js
+++ b/backend/controllers/assignmentController.js
@@ -1,0 +1,66 @@
+const Assignment = require('../models/Assignment');
+
+exports.createAssignment = async (req, res) => {
+  try {
+    const { courseId } = req.params;
+    const { title, description, dueDate } = req.body;
+    const assignment = new Assignment({
+      courseId,
+      teacherId: req.user.userId,
+      title,
+      description,
+      dueDate
+    });
+    await assignment.save();
+    res.status(201).json({ assignment });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to create assignment' });
+  }
+};
+
+exports.getAssignments = async (req, res) => {
+  try {
+    const { courseId } = req.params;
+    const assignments = await Assignment.find({ courseId }).sort({ createdAt: -1 });
+    res.json({ assignments });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch assignments' });
+  }
+};
+
+exports.submitAssignment = async (req, res) => {
+  try {
+    const { courseId, assignmentId } = req.params;
+    const file = req.file;
+    if (!file) return res.status(400).json({ message: 'File required' });
+
+    const assignment = await Assignment.findOne({ _id: assignmentId, courseId });
+    if (!assignment) return res.status(404).json({ message: 'Assignment not found' });
+
+    assignment.submissions.push({
+      studentId: req.user.userId,
+      fileName: file.originalname,
+      filePath: `/uploads/assignments/${file.filename}`
+    });
+    await assignment.save();
+    res.json({ message: 'Submission uploaded' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to submit assignment' });
+  }
+};
+
+exports.getSubmissions = async (req, res) => {
+  try {
+    const { courseId, assignmentId } = req.params;
+    const assignment = await Assignment.findOne({ _id: assignmentId, courseId })
+      .populate('submissions.studentId', 'firstName lastName phoneNumber');
+    if (!assignment) return res.status(404).json({ message: 'Assignment not found' });
+    res.json({ submissions: assignment.submissions });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch submissions' });
+  }
+};

--- a/backend/controllers/teacherController.js
+++ b/backend/controllers/teacherController.js
@@ -1,4 +1,5 @@
 const Teacher = require('../models/Teacher');
+const User = require('../models/User');
 
 exports.createTeacher = async (req, res) => {
   try {
@@ -12,6 +13,24 @@ exports.createTeacher = async (req, res) => {
     }
 
     await teacher.save();
+
+    // Also create a user account for login if phone number provided
+    if (data.phoneNumber && data.email) {
+      const existing = await User.findOne({ phoneNumber: data.phoneNumber });
+      if (!existing) {
+        const user = new User({
+          firstName: data.firstName,
+          lastName: data.lastName,
+          phoneNumber: data.phoneNumber,
+          password: data.email, // default password is email
+          education: data.education || 'N/A',
+          address: data.address || 'N/A',
+          userRole: 'teacher'
+        });
+        await user.save();
+      }
+    }
+
     res.status(201).json({ teacher });
   } catch (err) {
     console.error(err);

--- a/backend/index.js
+++ b/backend/index.js
@@ -20,6 +20,7 @@ const teacherRoutes = require('./routes/teacherRoutes');
 const noticeRoutes = require('./routes/noticeRoutes');
 const productRoutes = require('./routes/productRoutes');
 const paymentInquiryRoutes = require('./routes/paymentInquiryRoutes');
+const assignmentRoutes = require('./routes/assignmentRoutes');
 
 const app = express();
 
@@ -59,6 +60,7 @@ app.use('/api/teachers', teacherRoutes);
 app.use('/api/notices', noticeRoutes);
 app.use('/api', productRoutes);
 app.use('/api/inquiries', paymentInquiryRoutes);
+app.use('/api/courses/:courseId/assignments', assignmentRoutes);
 
 // Database connection handled via middleware for each request
 

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -34,3 +34,5 @@ exports.requireAdmin = exports.requireRole(['admin']);
 exports.requireTeacher = exports.requireRole(['teacher', 'admin']);
 exports.requireTeacherOrAssistant = exports.requireRole(['teacher', 'assistant', 'admin']);
 exports.requireStudent = exports.requireRole(['student', 'teacher', 'assistant', 'admin']);
+// Restrict to only students
+exports.requireStudentOnly = exports.requireRole(['student']);

--- a/backend/middleware/uploadAssignment.js
+++ b/backend/middleware/uploadAssignment.js
@@ -1,0 +1,32 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const defaultDir = path.join(__dirname, '..', 'uploads', 'assignments');
+const fallbackDir = '/tmp/uploads/assignments';
+
+let uploadDir = process.env.UPLOAD_DIR
+  ? path.join(process.env.UPLOAD_DIR, 'assignments')
+  : defaultDir;
+
+if (process.env.VERCEL && !process.env.UPLOAD_DIR) {
+  uploadDir = fallbackDir;
+}
+
+try {
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+} catch (err) {
+  uploadDir = fallbackDir;
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => cb(null, `${Date.now()}-${file.originalname}`)
+});
+
+module.exports = multer({ storage });

--- a/backend/models/Assignment.js
+++ b/backend/models/Assignment.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const submissionSchema = new mongoose.Schema({
+  studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+  fileName: String,
+  filePath: String,
+  submittedAt: { type: Date, default: Date.now }
+});
+
+const assignmentSchema = new mongoose.Schema({
+  courseId: { type: mongoose.Schema.Types.ObjectId, ref: 'Course', required: true },
+  teacherId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  title: { type: String, required: true },
+  description: String,
+  dueDate: Date,
+  submissions: [submissionSchema]
+}, { timestamps: true });
+
+module.exports = mongoose.model('Assignment', assignmentSchema);

--- a/backend/routes/assignmentRoutes.js
+++ b/backend/routes/assignmentRoutes.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router({ mergeParams: true });
+const controller = require('../controllers/assignmentController');
+const upload = require('../middleware/uploadAssignment');
+const { authenticateToken, requireTeacher, requireStudentOnly } = require('../middleware/authMiddleware');
+
+router.post('/', authenticateToken, requireTeacher, controller.createAssignment);
+router.get('/', authenticateToken, controller.getAssignments);
+router.post('/:assignmentId/submissions', authenticateToken, requireStudentOnly, upload.single('file'), controller.submitAssignment);
+router.get('/:assignmentId/submissions', authenticateToken, requireTeacher, controller.getSubmissions);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create Assignment model and controller for teacher-managed assignments
- allow teachers to upload and review assignment submissions
- generate teacher login accounts when admins create teachers
- add new auth helper and routes for assignments

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687230153d60832291002f597f947f17