### PR TITLE
Add teacher course management authorization

### DIFF
--- a/backend/controllers/noticeController.js
+++ b/backend/controllers/noticeController.js
@@ -2,10 +2,12 @@ const Notice = require('../models/Notice');
 const UserCourseAccess = require('../models/UserCourseAccess');
 const Course = require('../models/Course');
 const Teacher = require('../models/Teacher');
+const User = require('../models/User');
 
 exports.createNotice = async (req, res) => {
   try {
-    const { title, message, courseId, teacherId } = req.body;
+    const { title, message, courseId } = req.body;
+    let { teacherId } = req.body;
 
     if (!title || !message) {
       return res.status(400).json({ message: 'Title and message are required' });
@@ -13,6 +15,28 @@ exports.createNotice = async (req, res) => {
 
     if (!courseId && !teacherId) {
       return res.status(400).json({ message: 'Course or teacher must be specified' });
+    }
+
+    if (req.user.userRole === 'teacher') {
+      const user = await User.findById(req.user.userId);
+      if (!user) return res.status(401).json({ message: 'User not found' });
+
+      const teacherName = `${user.firstName} ${user.lastName}`.trim();
+
+      if (courseId) {
+        const course = await Course.findById(courseId);
+        if (!course) return res.status(404).json({ message: 'Course not found' });
+        if (course.teacherName !== teacherName) {
+          return res.status(403).json({ message: 'Access denied' });
+        }
+      }
+
+      if (!teacherId) {
+        const teacher = await Teacher.findOne({ phoneNumber: user.phoneNumber });
+        if (teacher) teacherId = teacher._id;
+      }
+    } else if (req.user.userRole !== 'admin') {
+      return res.status(403).json({ message: 'Access denied' });
     }
 
     const notice = new Notice({

--- a/backend/controllers/teacherController.js
+++ b/backend/controllers/teacherController.js
@@ -1,5 +1,6 @@
 const Teacher = require('../models/Teacher');
 const User = require('../models/User');
+const Course = require('../models/Course');
 
 exports.createTeacher = async (req, res) => {
   try {
@@ -134,5 +135,20 @@ exports.getAvailableSubjects = async (req, res) => {
   } catch (err) {
     console.error(err);
     res.status(500).json({ message: 'Failed to fetch subjects' });
+  }
+};
+
+// Fetch courses taught by the logged in teacher
+exports.getMyCourses = async (req, res) => {
+  try {
+    const user = await User.findById(req.user.userId);
+    if (!user) return res.status(404).json({ message: 'User not found' });
+
+    const teacherName = `${user.firstName} ${user.lastName}`.trim();
+    const courses = await Course.find({ teacherName });
+    res.json({ courses });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch courses' });
   }
 };

--- a/backend/middleware/courseOwnerMiddleware.js
+++ b/backend/middleware/courseOwnerMiddleware.js
@@ -1,0 +1,30 @@
+const Course = require('../models/Course');
+const User = require('../models/User');
+
+module.exports = async function courseOwnerOrAdmin(req, res, next) {
+  try {
+    const courseId = req.params.courseId || req.params.id;
+    if (!courseId) return res.status(400).json({ message: 'Course ID required' });
+    const course = await Course.findById(courseId);
+    if (!course) return res.status(404).json({ message: 'Course not found' });
+
+    const user = await User.findById(req.user.userId);
+    if (!user) return res.status(401).json({ message: 'User not found' });
+
+    if (req.user.userRole === 'admin') {
+      return next();
+    }
+
+    if (req.user.userRole === 'teacher') {
+      const teacherName = `${user.firstName} ${user.lastName}`.trim();
+      if (course.teacherName && course.teacherName.trim() === teacherName) {
+        return next();
+      }
+    }
+
+    return res.status(403).json({ message: 'Access denied' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Authorization failed' });
+  }
+};

--- a/backend/routes/assignmentRoutes.js
+++ b/backend/routes/assignmentRoutes.js
@@ -3,10 +3,11 @@ const router = express.Router({ mergeParams: true });
 const controller = require('../controllers/assignmentController');
 const upload = require('../middleware/uploadAssignment');
 const { authenticateToken, requireTeacher, requireStudentOnly } = require('../middleware/authMiddleware');
+const courseOwnerOrAdmin = require('../middleware/courseOwnerMiddleware');
 
-router.post('/', authenticateToken, requireTeacher, controller.createAssignment);
+router.post('/', authenticateToken, requireTeacher, courseOwnerOrAdmin, controller.createAssignment);
 router.get('/', authenticateToken, controller.getAssignments);
 router.post('/:assignmentId/submissions', authenticateToken, requireStudentOnly, upload.single('file'), controller.submitAssignment);
-router.get('/:assignmentId/submissions', authenticateToken, requireTeacher, controller.getSubmissions);
+router.get('/:assignmentId/submissions', authenticateToken, requireTeacher, courseOwnerOrAdmin, controller.getSubmissions);
 
 module.exports = router;

--- a/backend/routes/courseRoutes.js
+++ b/backend/routes/courseRoutes.js
@@ -5,28 +5,29 @@ const videoController = require('../controllers/uploadCourseVideo');
 const upload = require('../middleware/upload');
 const uploadSubtitle = require('../middleware/uploadSubtitle');
 const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const courseOwnerOrAdmin = require('../middleware/courseOwnerMiddleware');
 
 // Course CRUD
-router.post('/courses', authenticateToken, courseController.createCourse);
+router.post('/courses', authenticateToken, requireAdmin, courseController.createCourse);
 router.get('/courses', courseController.getAllCourses);
 router.get('/courses/stats', courseController.getCourseStats);
 router.get('/courses/available-grades', courseController.getAvailableGrades);
 router.get('/courses/:id', courseController.getCourseById);
-router.put('/courses/:id', authenticateToken, courseController.updateCourse);
-router.delete('/courses/:id', authenticateToken, courseController.deleteCourse);
+router.put('/courses/:id', authenticateToken, courseOwnerOrAdmin, courseController.updateCourse);
+router.delete('/courses/:id', authenticateToken, courseOwnerOrAdmin, courseController.deleteCourse);
 router.put('/courses/:id/full', authenticateToken, requireAdmin, courseController.updateFullCourse);
 
 // Add course content (manual embed or Bunny.net metadata)
 router.get('/courses/:id/content', courseController.getCourseContent);
-router.post('/courses/:id/content', authenticateToken, courseController.addCourseContent);
-router.put('/courses/:id/content/:contentId', authenticateToken, courseController.updateCourseContent);
-router.delete('/courses/:id/content/:contentId', authenticateToken, courseController.deleteCourseContent);
+router.post('/courses/:id/content', authenticateToken, courseOwnerOrAdmin, courseController.addCourseContent);
+router.put('/courses/:id/content/:contentId', authenticateToken, courseOwnerOrAdmin, courseController.updateCourseContent);
+router.delete('/courses/:id/content/:contentId', authenticateToken, courseOwnerOrAdmin, courseController.deleteCourseContent);
 
 // Subtitle management
-router.post('/courses/:id/subtitles', authenticateToken, uploadSubtitle.single('subtitleFile'), courseController.uploadSubtitle);
-router.delete('/courses/:id/subtitles/:subtitleId', authenticateToken, courseController.deleteSubtitle);
+router.post('/courses/:id/subtitles', authenticateToken, courseOwnerOrAdmin, uploadSubtitle.single('subtitleFile'), courseController.uploadSubtitle);
+router.delete('/courses/:id/subtitles/:subtitleId', authenticateToken, courseOwnerOrAdmin, courseController.deleteSubtitle);
 
 // Upload video file directly to Bunny.net and attach to course
-router.post('/courses/:id/upload-video', authenticateToken, upload.single('video'), videoController.uploadCourseVideo);
+router.post('/courses/:id/upload-video', authenticateToken, courseOwnerOrAdmin, upload.single('video'), videoController.uploadCourseVideo);
 
 module.exports = router;

--- a/backend/routes/noticeRoutes.js
+++ b/backend/routes/noticeRoutes.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/noticeController');
-const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const { authenticateToken, requireAdmin, requireTeacher } = require('../middleware/authMiddleware');
 
-router.post('/', authenticateToken, requireAdmin, controller.createNotice);
+router.post('/', authenticateToken, requireTeacher, controller.createNotice);
 router.get('/', controller.getNotices);
 router.get('/my', authenticateToken, controller.getMyNotices);
 

--- a/backend/routes/teacherRoutes.js
+++ b/backend/routes/teacherRoutes.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/teacherController');
-const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const { authenticateToken, requireAdmin, requireTeacher } = require('../middleware/authMiddleware');
+const courseOwnerOrAdmin = require('../middleware/courseOwnerMiddleware');
 
 router.post('/', authenticateToken, requireAdmin, controller.createTeacher);
 router.get('/', controller.getTeachers);
@@ -9,5 +10,8 @@ router.get('/available-subjects', controller.getAvailableSubjects);
 router.get('/:id', controller.getTeacherById);
 router.put('/:id', authenticateToken, requireAdmin, controller.updateTeacher);
 router.delete('/:id', authenticateToken, requireAdmin, controller.deleteTeacher);
+
+// Authenticated teachers can view the courses they teach
+router.get('/me/courses', authenticateToken, requireTeacher, controller.getMyCourses);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- new middleware `courseOwnerMiddleware` to ensure teachers can only modify their own courses
- allow teachers to retrieve their course list via `/api/teachers/me/courses`
- restrict course content/assignment routes to course owners
- permit teachers to create notices for their own classes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687234134b108322ada624ed8de367ac