### PR TITLE
Add teacher manage classes tile

### DIFF
--- a/frontend/src/pages/Dashboard/StudentDashboard.jsx
+++ b/frontend/src/pages/Dashboard/StudentDashboard.jsx
@@ -3,6 +3,7 @@ import './dashboard.css';
 
 const StudentDashboard = () => {
   const user = JSON.parse(localStorage.getItem('user'));
+  const isTeacher = user?.userRole === 'teacher';
 
   return (
     <div className="container py-5">
@@ -19,6 +20,9 @@ const StudentDashboard = () => {
 
       <div className="row gy-4 dashboard-tiles">
         <Tile title="My Classes" icon="📚" link="/dashboard/classes" />
+        {isTeacher && (
+          <Tile title="Manage Classes" icon="🛠️" link="/teacher/dashboard" />
+        )}
         <Tile title="Pending Payments" icon="💲" link="/dashboard/pending-payments" />
         <Tile title="Payment History" icon="💳" link="/dashboard/payments" />
         <Tile title="Recordings" icon="🎥" link="/dashboard/recordings" />


### PR DESCRIPTION
## Summary
- show a Manage Classes tile in the student dashboard when the logged-in user is a teacher

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `frontend` *(fails: @eslint/js not found)*

------
https://chatgpt.com/codex/tasks/task_e_687241bfad708322880ad1ea3f10d8fa