### PR TITLE
Restrict teacher home and dashboard

### DIFF
--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -15,7 +15,12 @@ const Login = () => {
       localStorage.setItem('token', res.data.token);
       localStorage.setItem('user', JSON.stringify(res.data.user));
       setMsg('Login successful!');
-      navigate('/');
+      const role = res.data.user.userRole;
+      if (role === 'teacher') {
+        navigate('/teacher/dashboard');
+      } else {
+        navigate('/');
+      }
     } catch (err) {
       setMsg('Login failed.');
     }

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -16,11 +16,17 @@ const Home = () => {
       </div>
 
       <div className="row gy-4">
-        <Tile title="Classes" icon="🎓" link="/classes" />
-        <Tile title="Shop" icon="🛒" link="/shop" />
-        <Tile title="Student Dashboard" icon="📊" link="/dashboard" />
-        <Tile title="Notices" icon="📢" link="/dashboard/notices" />
-        <Tile title="E-Library" icon="📚" link="/e-library" />
+        {user?.userRole === 'teacher' ? (
+          <Tile title="Teacher Dashboard" icon="🧑‍🏫" link="/teacher/dashboard" />
+        ) : (
+          <>
+            <Tile title="Classes" icon="🎓" link="/classes" />
+            <Tile title="Shop" icon="🛒" link="/shop" />
+            <Tile title="Student Dashboard" icon="📊" link="/dashboard" />
+            <Tile title="Notices" icon="📢" link="/dashboard/notices" />
+            <Tile title="E-Library" icon="📚" link="/e-library" />
+          </>
+        )}
         {user?.userRole === 'admin' && (
           <>
             <Tile title="Admin" icon="⚙️" link="/admin/courses" />

--- a/frontend/src/pages/Teacher/TeacherDashboard.jsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.jsx
@@ -8,9 +8,8 @@ const TeacherDashboard = () => {
 
   useEffect(() => {
     if (!user) return;
-    const name = `${user.firstName} ${user.lastName}`;
     api
-      .get(`/courses?teacherName=${encodeURIComponent(name)}`)
+      .get('/teachers/me/courses')
       .then(res => setCourses(res.data.courses || []))
       .catch(() => setCourses([]));
   }, [user]);


### PR DESCRIPTION
## Summary
- redirect teachers to dashboard on login
- show only teacher dashboard link on home for teachers
- fetch teacher courses from `/teachers/me/courses`

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872479c6184832291b12780177bda26