### PR TITLE
Add teacher notice posting and file assignments

### DIFF
--- a/backend/controllers/assignmentController.js
+++ b/backend/controllers/assignmentController.js
@@ -4,7 +4,8 @@ exports.createAssignment = async (req, res) => {
   try {
     const { courseId, title, description } = req.body;
     const teacherId = req.user.userId;
-    const assignment = new Assignment({ courseId, teacherId, title, description });
+    const fileUrl = req.file ? `/uploads/assignments/${req.file.filename}` : undefined;
+    const assignment = new Assignment({ courseId, teacherId, title, description, fileUrl });
     await assignment.save();
     res.status(201).json({ assignment });
   } catch (err) {

--- a/backend/middleware/uploadAssignment.js
+++ b/backend/middleware/uploadAssignment.js
@@ -1,0 +1,41 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const defaultDir = path.join(__dirname, '..', 'uploads', 'assignments');
+const fallbackDir = '/tmp/uploads/assignments';
+
+let uploadDir = process.env.UPLOAD_DIR
+  ? path.join(process.env.UPLOAD_DIR, 'assignments')
+  : defaultDir;
+
+if (process.env.VERCEL && !process.env.UPLOAD_DIR) {
+  uploadDir = fallbackDir;
+}
+
+try {
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+} catch (err) {
+  uploadDir = fallbackDir;
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const unique = `${Date.now()}-${file.originalname}`;
+    cb(null, unique);
+  }
+});
+
+const fileFilter = (req, file, cb) => {
+  const allowed = ['.pdf', '.doc', '.docx', '.txt'];
+  const ext = path.extname(file.originalname).toLowerCase();
+  cb(null, allowed.includes(ext));
+};
+
+module.exports = multer({ storage, fileFilter });

--- a/backend/models/Assignment.js
+++ b/backend/models/Assignment.js
@@ -5,6 +5,7 @@ const assignmentSchema = new mongoose.Schema({
   teacherId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   title: { type: String, required: true },
   description: String,
+  fileUrl: String,
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/backend/routes/assignmentRoutes.js
+++ b/backend/routes/assignmentRoutes.js
@@ -2,8 +2,10 @@ const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/assignmentController');
 const { authenticateToken, requireTeacher } = require('../middleware/authMiddleware');
+const { checkCourseAccess } = require('../middleware/courseAccessMiddleware');
+const uploadAssignment = require('../middleware/uploadAssignment');
 
-router.post('/', authenticateToken, requireTeacher, controller.createAssignment);
-router.get('/course/:courseId', authenticateToken, controller.getAssignmentsByCourse);
+router.post('/', authenticateToken, requireTeacher, uploadAssignment.single('file'), controller.createAssignment);
+router.get('/course/:courseId', authenticateToken, checkCourseAccess, controller.getAssignmentsByCourse);
 
 module.exports = router;

--- a/backend/routes/noticeRoutes.js
+++ b/backend/routes/noticeRoutes.js
@@ -1,9 +1,9 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/noticeController');
-const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const { authenticateToken, requireAdmin, requireTeacher } = require('../middleware/authMiddleware');
 
-router.post('/', authenticateToken, requireAdmin, controller.createNotice);
+router.post('/', authenticateToken, requireTeacher, controller.createNotice);
 router.get('/', controller.getNotices);
 router.get('/my', authenticateToken, controller.getMyNotices);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,7 @@ import PaymentSuccess from './pages/PaymentSuccess';
 // Teacher Pages
 import TeacherDashboard from './pages/Teacher/TeacherDashboard';
 import AddAssignment from './pages/Teacher/AddAssignment';
+import AddNotice from './pages/Teacher/AddNotice';
 
 // Admin Pages
 import CourseUploader from './pages/Admin/CourseUploader';
@@ -109,6 +110,7 @@ function App() {
         <Route path="/teacher/dashboard" element={<RequireTeacher><TeacherDashboard /></RequireTeacher>} />
         <Route path="/teacher/courses/:courseId/upload" element={<RequireTeacher><CourseUploader /></RequireTeacher>} />
         <Route path="/teacher/courses/:courseId/assignments/new" element={<RequireTeacher><AddAssignment /></RequireTeacher>} />
+        <Route path="/teacher/notices/new" element={<RequireTeacher><AddNotice /></RequireTeacher>} />
 
         {/* Admin */}
         <Route path="/admin/courses" element={<RequireAdmin><CourseList /></RequireAdmin>} />

--- a/frontend/src/pages/Dashboard/Assignments.jsx
+++ b/frontend/src/pages/Dashboard/Assignments.jsx
@@ -27,6 +27,11 @@ const Assignments = () => {
           <li key={a._id} className="list-group-item">
             <strong>{a.title}</strong>
             {a.description && <p className="mb-1">{a.description}</p>}
+            {a.fileUrl && (
+              <a href={a.fileUrl} className="d-block" download>
+                Download File
+              </a>
+            )}
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/Teacher/AddAssignment.jsx
+++ b/frontend/src/pages/Teacher/AddAssignment.jsx
@@ -7,12 +7,20 @@ const AddAssignment = () => {
   const navigate = useNavigate();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [file, setFile] = useState(null);
   const [message, setMessage] = useState('');
 
   const submit = async (e) => {
     e.preventDefault();
     try {
-      await api.post('/assignments', { courseId, title, description });
+      const formData = new FormData();
+      formData.append('courseId', courseId);
+      formData.append('title', title);
+      formData.append('description', description);
+      if (file) formData.append('file', file);
+      await api.post('/assignments', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
+      });
       setMessage('Assignment created');
       navigate('/teacher/dashboard');
     } catch (err) {
@@ -24,7 +32,7 @@ const AddAssignment = () => {
     <div className="container py-4">
       <h4>Add Assignment</h4>
       {message && <div className="alert alert-info">{message}</div>}
-      <form onSubmit={submit}>
+      <form onSubmit={submit} encType="multipart/form-data">
         <input
           className="form-control mb-2"
           placeholder="Title"
@@ -37,6 +45,11 @@ const AddAssignment = () => {
           placeholder="Description"
           value={description}
           onChange={(e) => setDescription(e.target.value)}
+        />
+        <input
+          type="file"
+          className="form-control mb-2"
+          onChange={(e) => setFile(e.target.files[0])}
         />
         <button className="btn btn-primary">Save</button>
       </form>

--- a/frontend/src/pages/Teacher/AddNotice.jsx
+++ b/frontend/src/pages/Teacher/AddNotice.jsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+const AddNotice = () => {
+  const [form, setForm] = useState({ title: '', message: '', courseId: '' });
+  const [courses, setCourses] = useState([]);
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    api
+      .get('/teachers/me/courses')
+      .then(res => setCourses(res.data.courses || []))
+      .catch(() => setCourses([]));
+  }, []);
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const submit = async e => {
+    e.preventDefault();
+    try {
+      await api.post('/notices', form);
+      setMessage('Notice created');
+      navigate('/teacher/dashboard');
+    } catch (err) {
+      setMessage('Creation failed');
+    }
+  };
+
+  return (
+    <div className="container py-4">
+      <h4>Add Notice</h4>
+      {message && <div className="alert alert-info">{message}</div>}
+      <form onSubmit={submit}>
+        <input
+          className="form-control mb-2"
+          name="title"
+          placeholder="Title"
+          value={form.title}
+          onChange={handleChange}
+          required
+        />
+        <textarea
+          className="form-control mb-2"
+          name="message"
+          placeholder="Message"
+          value={form.message}
+          onChange={handleChange}
+          required
+        />
+        <select
+          className="form-control mb-2"
+          name="courseId"
+          value={form.courseId}
+          onChange={handleChange}
+        >
+          <option value="">Select Course (optional)</option>
+          {courses.map(c => (
+            <option key={c._id} value={c._id}>{c.title}</option>
+          ))}
+        </select>
+        <button className="btn btn-primary">Create</button>
+      </form>
+    </div>
+  );
+};
+
+export default AddNotice;

--- a/frontend/src/pages/Teacher/TeacherDashboard.jsx
+++ b/frontend/src/pages/Teacher/TeacherDashboard.jsx
@@ -28,8 +28,11 @@ const TeacherDashboard = () => {
               <Link className="btn btn-sm btn-primary me-2" to={`/teacher/courses/${c._id}/upload`}>
                 Manage Content
               </Link>
-              <Link className="btn btn-sm btn-warning" to={`/teacher/courses/${c._id}/assignments/new`}>
+              <Link className="btn btn-sm btn-warning me-2" to={`/teacher/courses/${c._id}/assignments/new`}>
                 Add Assignment
+              </Link>
+              <Link className="btn btn-sm btn-success" to="/teacher/notices/new">
+                Add Notice
               </Link>
             </div>
           </li>


### PR DESCRIPTION
## Summary
- enable teachers to create notices
- restrict assignment access to enrolled students and allow file upload
- support assignment files with new upload middleware
- show assignment file downloads in dashboard
- add teacher notice creation page and route

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68724ba35cfc8322a12ce8640643fa8f