### PR TITLE
Allow teachers to identify student submissions

### DIFF
--- a/backend/controllers/assignmentSubmissionController.js
+++ b/backend/controllers/assignmentSubmissionController.js
@@ -9,7 +9,13 @@ exports.submitAssignment = async (req, res) => {
       process.env.BASE_URL ||
       (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `${req.protocol}://${req.get('host')}`);
     const fileUrl = `${baseUrl}/uploads/submissions/${req.file.filename}`;
-    const submission = new AssignmentSubmission({ assignmentId, studentId, fileUrl });
+    const originalName = req.file.originalname;
+    const submission = new AssignmentSubmission({
+      assignmentId,
+      studentId,
+      fileUrl,
+      originalName
+    });
     await submission.save();
     res.status(201).json({ submission });
   } catch (err) {

--- a/backend/middleware/uploadSubmission.js
+++ b/backend/middleware/uploadSubmission.js
@@ -25,7 +25,10 @@ try {
 const storage = multer.diskStorage({
   destination: (req, file, cb) => cb(null, uploadDir),
   filename: (req, file, cb) => {
-    const unique = `${Date.now()}-${file.originalname}`;
+    const assignmentId = req.params.assignmentId || 'assignment';
+    const studentId = req.user ? req.user.userId : 'student';
+    const ext = path.extname(file.originalname).toLowerCase();
+    const unique = `${assignmentId}-${studentId}-${Date.now()}${ext}`;
     cb(null, unique);
   }
 });

--- a/backend/models/AssignmentSubmission.js
+++ b/backend/models/AssignmentSubmission.js
@@ -4,6 +4,7 @@ const assignmentSubmissionSchema = new mongoose.Schema({
   assignmentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Assignment', required: true },
   studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   fileUrl: { type: String, required: true },
+  originalName: { type: String, required: true },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/frontend/src/pages/Teacher/AssignmentSubmissions.jsx
+++ b/frontend/src/pages/Teacher/AssignmentSubmissions.jsx
@@ -17,16 +17,20 @@ const AssignmentSubmissions = () => {
     <div className="container py-4">
       <h4>Submissions</h4>
       <ul className="list-group">
-        {submissions.map((s) => (
-          <li key={s._id} className="list-group-item d-flex justify-content-between">
-            <span>
-              {s.studentId?.firstName} {s.studentId?.lastName}
-            </span>
-            <a className="btn btn-sm btn-outline-primary" href={s.fileUrl} download>
-              Download
-            </a>
-          </li>
-        ))}
+        {submissions.map((s) => {
+          const ext = s.fileUrl.split('.').pop().split(/[#?]/)[0];
+          const fileName = `${s.studentId?.firstName || 'student'}-${s.studentId?.lastName || ''}-${assignmentId}.${ext}`;
+          return (
+            <li key={s._id} className="list-group-item d-flex justify-content-between">
+              <span>
+                {s.studentId?.firstName} {s.studentId?.lastName} – {s.originalName}
+              </span>
+              <a className="btn btn-sm btn-outline-primary" href={s.fileUrl} download={fileName}>
+                Download
+              </a>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `originalName` to assignment submission schema
- store original filename during upload
- incorporate student and assignment IDs in stored filename
- show original filename when teachers view submissions and download files with meaningful names

## Testing
- `npx jest --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68726a6007888322835b511a55bb0e93