### PR TITLE
Implement assignment marking

### DIFF
--- a/backend/controllers/assignmentController.js
+++ b/backend/controllers/assignmentController.js
@@ -27,3 +27,14 @@ exports.getAssignmentsByCourse = async (req, res) => {
     res.status(500).json({ message: 'Failed to get assignments' });
   }
 };
+
+exports.getAssignmentById = async (req, res) => {
+  try {
+    const assignment = await Assignment.findById(req.params.id);
+    if (!assignment) return res.status(404).json({ message: 'Assignment not found' });
+    res.json({ assignment });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to get assignment' });
+  }
+};

--- a/backend/controllers/assignmentSubmissionController.js
+++ b/backend/controllers/assignmentSubmissionController.js
@@ -34,3 +34,31 @@ exports.getSubmissions = async (req, res) => {
     res.status(500).json({ message: 'Failed to fetch submissions' });
   }
 };
+
+exports.getMySubmission = async (req, res) => {
+  try {
+    const { assignmentId } = req.params;
+    const studentId = req.user.userId;
+    const submission = await AssignmentSubmission.findOne({ assignmentId, studentId });
+    if (!submission) return res.status(404).json({ message: 'Submission not found' });
+    res.json({ submission });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch submission' });
+  }
+};
+
+exports.markSubmission = async (req, res) => {
+  try {
+    const { assignmentId, submissionId } = req.params;
+    const { marks } = req.body;
+    const submission = await AssignmentSubmission.findOne({ _id: submissionId, assignmentId });
+    if (!submission) return res.status(404).json({ message: 'Submission not found' });
+    submission.marks = marks;
+    await submission.save();
+    res.json({ submission });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to update marks' });
+  }
+};

--- a/backend/models/AssignmentSubmission.js
+++ b/backend/models/AssignmentSubmission.js
@@ -5,6 +5,7 @@ const assignmentSubmissionSchema = new mongoose.Schema({
   studentId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   fileUrl: { type: String, required: true },
   originalName: { type: String, required: true },
+  marks: { type: Number },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/backend/routes/assignmentRoutes.js
+++ b/backend/routes/assignmentRoutes.js
@@ -8,6 +8,7 @@ const submissionRoutes = require('./assignmentSubmissionRoutes');
 
 router.post('/', authenticateToken, requireTeacher, uploadAssignment.single('file'), controller.createAssignment);
 router.get('/course/:courseId', authenticateToken, checkCourseAccess, controller.getAssignmentsByCourse);
+router.get('/:id', authenticateToken, controller.getAssignmentById);
 
 router.use('/:assignmentId/submissions', submissionRoutes);
 

--- a/backend/routes/assignmentSubmissionRoutes.js
+++ b/backend/routes/assignmentSubmissionRoutes.js
@@ -6,5 +6,7 @@ const uploadSubmission = require('../middleware/uploadSubmission');
 
 router.post('/', authenticateToken, uploadSubmission.single('file'), controller.submitAssignment);
 router.get('/', authenticateToken, requireTeacher, controller.getSubmissions);
+router.get('/mine', authenticateToken, controller.getMySubmission);
+router.put('/:submissionId/mark', authenticateToken, requireTeacher, controller.markSubmission);
 
 module.exports = router;

--- a/frontend/src/pages/Dashboard/ClassDashboard.jsx
+++ b/frontend/src/pages/Dashboard/ClassDashboard.jsx
@@ -28,6 +28,7 @@ const ClassDashboard = () => {
       <div className="row gy-4 dashboard-tiles">
         <Tile title="Recordings" icon="🎥" link={`/dashboard/recordings/${classId}`} />
         <Tile title="Assignments" icon="📝" link={`/dashboard/assignments/${classId}`} />
+        <Tile title="Marks" icon="📊" link={`/dashboard/marks/${classId}`} />
         <Tile title="Notices" icon="📢" link="/dashboard/notices" />
       </div>
     </div>

--- a/frontend/src/pages/Dashboard/Marks.jsx
+++ b/frontend/src/pages/Dashboard/Marks.jsx
@@ -1,20 +1,40 @@
 import { useParams } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import { Bar } from 'react-chartjs-2';
 import { Chart as ChartJS, BarElement, CategoryScale, LinearScale } from 'chart.js';
+import api from '../../api';
 
 ChartJS.register(BarElement, CategoryScale, LinearScale);
 
 const Marks = () => {
   const { classId } = useParams();
-  const papers = ['P1', 'P2', 'P3', 'P4'];
-  const marks = [75, 60, 88, 95];
+  const [labels, setLabels] = useState([]);
+  const [marks, setMarks] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await api.get(`/assignments/course/${classId}`);
+      const assignments = res.data.assignments || [];
+      const submissions = await Promise.all(
+        assignments.map((a) =>
+          api
+            .get(`/assignments/${a._id}/submissions/mine`)
+            .then((r) => r.data.submission)
+            .catch(() => null)
+        )
+      );
+      setLabels(assignments.map((a) => a.title));
+      setMarks(submissions.map((s) => (s ? s.marks || 0 : 0)));
+    };
+    load();
+  }, [classId]);
 
   return (
     <div className="container py-4">
       <h4>Marks – {classId}</h4>
       <Bar
         data={{
-          labels: papers,
+          labels,
           datasets: [
             {
               label: 'Marks',

--- a/frontend/src/pages/Teacher/AssignmentSubmissions.jsx
+++ b/frontend/src/pages/Teacher/AssignmentSubmissions.jsx
@@ -5,17 +5,30 @@ import api from '../../api';
 const AssignmentSubmissions = () => {
   const { assignmentId } = useParams();
   const [submissions, setSubmissions] = useState([]);
+  const [assignment, setAssignment] = useState(null);
+  const [marks, setMarks] = useState({});
 
   useEffect(() => {
+    api
+      .get(`/assignments/${assignmentId}`)
+      .then((res) => setAssignment(res.data.assignment))
+      .catch(() => setAssignment(null));
+
     api
       .get(`/assignments/${assignmentId}/submissions`)
       .then((res) => setSubmissions(res.data.submissions || []))
       .catch(() => setSubmissions([]));
   }, [assignmentId]);
 
+  const saveMarks = async (id) => {
+    const mark = marks[id];
+    await api.put(`/assignments/${assignmentId}/submissions/${id}/mark`, { marks: mark });
+    setSubmissions((prev) => prev.map((s) => (s._id === id ? { ...s, marks: mark } : s)));
+  };
+
   return (
     <div className="container py-4">
-      <h4>Submissions</h4>
+      <h4>Submissions{assignment ? ` – ${assignment.title}` : ''}</h4>
       <ul className="list-group">
         {submissions.map((s) => {
           const ext = s.fileUrl.split('.').pop().split(/[#?]/)[0];
@@ -27,18 +40,23 @@ const AssignmentSubmissions = () => {
                 {s.studentId?.firstName} {s.studentId?.lastName}
                 {studentCode && <small className="text-muted ms-1">({studentCode})</small>} – {s.originalName}
               </span>
-              <div className="d-flex">
-                <a
-                  className="btn btn-sm btn-outline-secondary me-2"
-                  href={s.fileUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+              <div className="d-flex align-items-center">
+                <a className="btn btn-sm btn-outline-secondary me-2" href={s.fileUrl} target="_blank" rel="noopener noreferrer">
                   View
                 </a>
-                <a className="btn btn-sm btn-primary" href={s.fileUrl} download={fileName}>
+                <a className="btn btn-sm btn-primary me-2" href={s.fileUrl} download={fileName}>
                   Download
                 </a>
+                <input
+                  type="number"
+                  className="form-control form-control-sm me-2"
+                  style={{ width: '80px' }}
+                  value={marks[s._id] ?? s.marks ?? ''}
+                  onChange={(e) => setMarks({ ...marks, [s._id]: e.target.value })}
+                />
+                <button className="btn btn-sm btn-success" onClick={() => saveMarks(s._id)}>
+                  Save
+                </button>
               </div>
             </li>
           );


### PR DESCRIPTION
## Summary
- add `marks` field to assignment submissions
- allow teachers to mark submissions and students to fetch their own
- expose single-assignment API
- show marks input and assignment title on teacher submission page
- display marks chart for a class
- link marks page from class dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68726f64626083228a2a63a040dd1f21