### PR TITLE
Remove bar chart from marks page

### DIFF
--- a/frontend/src/pages/Dashboard/Marks.jsx
+++ b/frontend/src/pages/Dashboard/Marks.jsx
@@ -1,10 +1,9 @@
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import { Bar } from 'react-chartjs-2';
-import { Chart as ChartJS, BarElement, CategoryScale, LinearScale } from 'chart.js';
+// Previously this page displayed a bar chart using Chart.js. The requirements
+// now specify showing only the numeric marks without any chart, so all chart
+// related imports and code have been removed.
 import api from '../../api';
-
-ChartJS.register(BarElement, CategoryScale, LinearScale);
 
 const Marks = () => {
   const { classId } = useParams();
@@ -38,20 +37,7 @@ const Marks = () => {
   return (
     <div className="container py-4">
       <h4>Marks – {classId}</h4>
-      <Bar
-        data={{
-          labels,
-          datasets: [
-            {
-              label: 'Marks',
-              data: marks,
-              backgroundColor: 'rgba(0,123,255,0.6)'
-            }
-          ]
-        }}
-        height={300}
-        options={{ maintainAspectRatio: false }}
-      />
+      {/* The bar chart was removed to simplify the interface */}
       <table className="table table-striped mt-4">
         <thead>
           <tr>


### PR DESCRIPTION
## Summary
- simplify marks view
- remove bar chart from Dashboard Marks page

## Testing
- `npm run lint` *(fails: cannot find module)*
- `npm install` *(fails: internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68727a10da3c8322a0a235dc2da61e86