### PR TITLE
Add assistant management

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -52,6 +52,52 @@ exports.getMyCourses = async (req, res) => {
   res.json({ classes: courses });
 };
 
+// Create a new user (Admin only)
+exports.createUser = async (req, res) => {
+  try {
+    const { firstName, lastName, phoneNumber, password, userRole, education, address } = req.body;
+
+    if (!firstName || !lastName || !phoneNumber || !password) {
+      return res.status(400).json({ message: 'Missing required fields' });
+    }
+
+    const validRoles = ['student', 'teacher', 'assistant', 'admin'];
+    if (userRole && !validRoles.includes(userRole)) {
+      return res.status(400).json({ message: 'Invalid role specified' });
+    }
+
+    const existing = await User.findOne({ phoneNumber });
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+
+    const newUser = new User({
+      firstName,
+      lastName,
+      phoneNumber,
+      password,
+      education: education || 'N/A',
+      address: address || 'N/A',
+      userRole: userRole || 'assistant'
+    });
+
+    await newUser.save();
+
+    res.status(201).json({
+      user: {
+        id: newUser._id,
+        firstName: newUser.firstName,
+        lastName: newUser.lastName,
+        phoneNumber: newUser.phoneNumber,
+        userRole: newUser.userRole
+      }
+    });
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
 // Update user role (Admin only)
 exports.updateUserRole = async (req, res) => {
   try {

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -28,10 +28,17 @@ router.get('/role/:role',
 );
 
 // Update user role - Admin only
-router.put('/:userId/role', 
-  authMiddleware.authenticateToken, 
-  authMiddleware.requireAdmin, 
+router.put('/:userId/role',
+  authMiddleware.authenticateToken,
+  authMiddleware.requireAdmin,
   userController.updateUserRole
+);
+
+// Create a new user - Admin only
+router.post('/',
+  authMiddleware.authenticateToken,
+  authMiddleware.requireAdmin,
+  userController.createUser
 );
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -57,6 +57,8 @@ import InquiryList from './pages/Admin/InquiryList';
 import TeacherListAdmin from './pages/Admin/TeacherList';
 import CreateTeacher from './pages/Admin/CreateTeacher';
 import EditTeacher from './pages/Admin/EditTeacher';
+import AssistantList from './pages/Admin/AssistantList';
+import CreateAssistant from './pages/Admin/CreateAssistant';
 import NoticeList from './pages/Admin/NoticeList';
 import CreateNotice from './pages/Admin/CreateNotice';
 import CreateProduct from './pages/Admin/CreateProduct';
@@ -137,6 +139,8 @@ function App() {
         <Route path="/admin/teachers" element={<RequireAdmin><TeacherListAdmin /></RequireAdmin>} />
         <Route path="/admin/teachers/create" element={<RequireAdmin><CreateTeacher /></RequireAdmin>} />
         <Route path="/admin/teachers/:teacherId/edit" element={<RequireAdmin><EditTeacher /></RequireAdmin>} />
+        <Route path="/admin/assistants" element={<RequireAdmin><AssistantList /></RequireAdmin>} />
+        <Route path="/admin/assistants/create" element={<RequireAdmin><CreateAssistant /></RequireAdmin>} />
         <Route path="/admin/notices" element={<RequireAdmin><NoticeList /></RequireAdmin>} />
         <Route path="/admin/notices/create" element={<RequireAdmin><CreateNotice /></RequireAdmin>} />
         <Route path="/admin/products" element={<RequireAdmin><ProductList /></RequireAdmin>} />

--- a/frontend/src/pages/Admin/AssistantList.jsx
+++ b/frontend/src/pages/Admin/AssistantList.jsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import api from '../../api';
+
+function AssistantList() {
+  const [assistants, setAssistants] = useState([]);
+
+  const load = () => {
+    api
+      .get('/users/role/assistant')
+      .then(res => setAssistants(res.data || []))
+      .catch(() => setAssistants([]));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  return (
+    <div className="container mt-4">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2>Assistants</h2>
+        <Link className="btn btn-success" to="/admin/assistants/create">New Assistant</Link>
+      </div>
+      <ul className="list-group">
+        {assistants.map(a => (
+          <li key={a._id} className="list-group-item d-flex justify-content-between">
+            <span>{a.firstName} {a.lastName} - {a.phoneNumber}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default AssistantList;

--- a/frontend/src/pages/Admin/CreateAssistant.jsx
+++ b/frontend/src/pages/Admin/CreateAssistant.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+function CreateAssistant() {
+  const [form, setForm] = useState({
+    firstName: '',
+    lastName: '',
+    phoneNumber: '',
+    password: '',
+    confirmPassword: '',
+    education: '',
+    address: ''
+  });
+  const [message, setMessage] = useState('');
+  const navigate = useNavigate();
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (form.password !== form.confirmPassword) {
+      setMessage('Passwords do not match');
+      return;
+    }
+    try {
+      await api.post('/users', { ...form, userRole: 'assistant' });
+      setMessage('Assistant created');
+      navigate('/admin/assistants');
+    } catch (err) {
+      setMessage('Creation failed');
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Create Assistant</h2>
+      {message && <div className="alert alert-info">{message}</div>}
+      <form onSubmit={handleSubmit}>
+        <input className="form-control mb-2" name="firstName" placeholder="First Name" value={form.firstName} onChange={handleChange} required />
+        <input className="form-control mb-2" name="lastName" placeholder="Last Name" value={form.lastName} onChange={handleChange} required />
+        <input className="form-control mb-2" name="phoneNumber" placeholder="Phone" value={form.phoneNumber} onChange={handleChange} required />
+        <input className="form-control mb-2" type="password" name="password" placeholder="Password" value={form.password} onChange={handleChange} required />
+        <input className="form-control mb-2" type="password" name="confirmPassword" placeholder="Confirm Password" value={form.confirmPassword} onChange={handleChange} required />
+        <input className="form-control mb-2" name="education" placeholder="Education" value={form.education} onChange={handleChange} />
+        <input className="form-control mb-2" name="address" placeholder="Address" value={form.address} onChange={handleChange} />
+        <button className="btn btn-primary">Create</button>
+      </form>
+    </div>
+  );
+}
+
+export default CreateAssistant;


### PR DESCRIPTION
## Summary
- allow admins to create users directly via new backend endpoint
- list assistants and add new assistants from the dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872841cd218832297bfe3f71af908fa