### PR TITLE
Enable assistant course assignment management

### DIFF
--- a/backend/middleware/courseAccessMiddleware.js
+++ b/backend/middleware/courseAccessMiddleware.js
@@ -6,8 +6,12 @@ exports.checkCourseAccess = async (req, res, next) => {
   const userId = req.user.userId;
   const { courseId } = req.params;
 
-  // allow teacher or admin users to access their own courses without purchase
-  if (req.user.userRole === 'teacher' || req.user.userRole === 'admin') {
+  // allow teacher, assistant or admin users to access courses without purchase
+  if (req.user.userRole === 'assistant' || req.user.userRole === 'admin') {
+    return next();
+  }
+
+  if (req.user.userRole === 'teacher') {
     try {
       const user = await User.findById(userId);
       const course = await Course.findById(courseId);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -46,6 +46,8 @@ import AssistantAssignmentSubmissions from './pages/Assistant/AssignmentSubmissi
 // Assistant Pages
 import AssistantDashboard from './pages/Assistant/AssistantDashboard';
 import TeacherAssignments from './pages/Assistant/TeacherAssignments';
+import AssistantTeacherCourses from './pages/Assistant/TeacherCourses';
+import AssistantCourseAssignments from './pages/Assistant/CourseAssignments';
 
 // Admin Pages
 import CourseUploader from './pages/Admin/CourseUploader';
@@ -126,6 +128,8 @@ function App() {
 
         {/* Assistant */}
         <Route path="/assistant/dashboard" element={<RequireAssistant><AssistantDashboard /></RequireAssistant>} />
+        <Route path="/assistant/teacher/:teacherId/courses" element={<RequireAssistant><AssistantTeacherCourses /></RequireAssistant>} />
+        <Route path="/assistant/course/:courseId/assignments" element={<RequireAssistant><AssistantCourseAssignments /></RequireAssistant>} />
         <Route path="/assistant/teacher/:teacherId/assignments" element={<RequireAssistant><TeacherAssignments /></RequireAssistant>} />
         <Route path="/assistant/assignments/:assignmentId/submissions" element={<RequireAssistant><AssistantAssignmentSubmissions /></RequireAssistant>} />
 

--- a/frontend/src/pages/Assistant/AssistantDashboard.jsx
+++ b/frontend/src/pages/Assistant/AssistantDashboard.jsx
@@ -19,8 +19,8 @@ const AssistantDashboard = () => {
         {teachers.map(t => (
           <li key={t._id} className="list-group-item d-flex justify-content-between align-items-center">
             <span>{t.firstName} {t.lastName}</span>
-            <Link className="btn btn-sm btn-primary" to={`/assistant/teacher/${t._id}/assignments`}>
-              View Assignments
+            <Link className="btn btn-sm btn-primary" to={`/assistant/teacher/${t._id}/courses`}>
+              View Classes
             </Link>
           </li>
         ))}

--- a/frontend/src/pages/Assistant/CourseAssignments.jsx
+++ b/frontend/src/pages/Assistant/CourseAssignments.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import api from '../../api';
+
+const CourseAssignments = () => {
+  const { courseId } = useParams();
+  const [assignments, setAssignments] = useState([]);
+  const [course, setCourse] = useState(null);
+
+  useEffect(() => {
+    api
+      .get(`/courses/${courseId}`)
+      .then(res => setCourse(res.data.course))
+      .catch(() => setCourse(null));
+
+    api
+      .get(`/assignments/course/${courseId}`)
+      .then(res => setAssignments(res.data.assignments || []))
+      .catch(() => setAssignments([]));
+  }, [courseId]);
+
+  return (
+    <div className="container py-4">
+      <h4>Assignments{course ? ` – ${course.title}` : ''}</h4>
+      <ul className="list-group">
+        {assignments.map(a => (
+          <li key={a._id} className="list-group-item d-flex justify-content-between">
+            <span>{a.title}</span>
+            <Link className="btn btn-sm btn-outline-secondary" to={`/assistant/assignments/${a._id}/submissions`}>
+              View Submissions
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default CourseAssignments;

--- a/frontend/src/pages/Assistant/TeacherCourses.jsx
+++ b/frontend/src/pages/Assistant/TeacherCourses.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import api from '../../api';
+
+const TeacherCourses = () => {
+  const { teacherId } = useParams();
+  const [courses, setCourses] = useState([]);
+  const [teacher, setTeacher] = useState(null);
+
+  useEffect(() => {
+    api
+      .get(`/teachers/${teacherId}`)
+      .then(res => setTeacher(res.data.teacher))
+      .catch(() => setTeacher(null));
+
+    api
+      .get(`/teachers/${teacherId}/courses`)
+      .then(res => setCourses(res.data.courses || []))
+      .catch(() => setCourses([]));
+  }, [teacherId]);
+
+  return (
+    <div className="container py-4">
+      <h4>
+        {teacher ? `${teacher.firstName} ${teacher.lastName}'s Classes` : 'Classes'}
+      </h4>
+      <ul className="list-group">
+        {courses.map(c => (
+          <li key={c._id} className="list-group-item d-flex justify-content-between">
+            <span>{c.title}</span>
+            <Link className="btn btn-sm btn-outline-secondary" to={`/assistant/course/${c._id}/assignments`}>
+              View Assignments
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default TeacherCourses;


### PR DESCRIPTION
## Summary
- allow assistants to bypass course access checks
- link assistant dashboard to teacher classes
- add assistant pages to browse courses and assignments
- wire new routes in the frontend

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68728fb13f7883229a75980aaf6fbb1a