### PR TITLE
Add Assistant dashboard quick access

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -18,6 +18,8 @@ const Home = () => {
       <div className="row gy-4">
         {user?.userRole === 'teacher' ? (
           <Tile title="Teacher Dashboard" icon="🧑‍🏫" link="/teacher/dashboard" />
+        ) : user?.userRole === 'assistant' ? (
+          <Tile title="Assistant Dashboard" icon="🧑‍💼" link="/assistant/dashboard" />
         ) : (
           <>
             <Tile title="Classes" icon="🎓" link="/classes" />


### PR DESCRIPTION
## Summary
- add a quick-access tile on the Home page for assistants

## Testing
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687295473efc832296eb5a8f302ae189