### PR TITLE
Support image uploads for bank deposit slips

### DIFF
--- a/backend/controllers/bankPaymentController.js
+++ b/backend/controllers/bankPaymentController.js
@@ -9,9 +9,9 @@ exports.submitBankPayment = async (req, res) => {
     (process.env.VERCEL_URL
       ? `https://${process.env.VERCEL_URL}`
       : `${req.protocol}://${req.get('host')}`);
-  const zipUrl = req.file
+  const slipUrl = req.file
     ? `${baseUrl}/uploads/bank-slips/${req.file.filename}`
-    : req.body.zipUrl;
+    : req.body.slipUrl;
 
   const existing = await UserCourseAccess.findOne({
     userId,
@@ -20,11 +20,11 @@ exports.submitBankPayment = async (req, res) => {
   });
   if (existing) return res.status(400).json({ message: 'You already have access to this course until the 8th.' });
 
-  if (!zipUrl) {
+  if (!slipUrl) {
     return res.status(400).json({ message: 'Slip file is required' });
   }
 
-  const request = new BankPaymentRequest({ userId, courseId, zipUrl });
+  const request = new BankPaymentRequest({ userId, courseId, slipUrl });
   await request.save();
   res.status(201).json({ message: 'Bank payment submitted', request });
 };

--- a/backend/middleware/uploadBankSlip.js
+++ b/backend/middleware/uploadBankSlip.js
@@ -33,7 +33,7 @@ const storage = multer.diskStorage({
 });
 
 const fileFilter = (req, file, cb) => {
-  const allowed = ['.zip'];
+  const allowed = ['.jpg', '.jpeg', '.png'];
   const ext = path.extname(file.originalname).toLowerCase();
   cb(null, allowed.includes(ext));
 };

--- a/backend/models/BankPaymentRequest.js
+++ b/backend/models/BankPaymentRequest.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const bankPaymentRequestSchema = new mongoose.Schema({
   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   courseId: { type: mongoose.Schema.Types.ObjectId, ref: 'Course', required: true },
-  zipUrl: { type: String, required: true },
+  slipUrl: { type: String, required: true },
   status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
   createdAt: { type: Date, default: Date.now }
 });

--- a/frontend/src/pages/Admin/BankPaymentRequests.jsx
+++ b/frontend/src/pages/Admin/BankPaymentRequests.jsx
@@ -28,16 +28,31 @@ function BankPaymentRequests() {
       <h2>Bank Payment Requests</h2>
       <ul className="list-group">
         {requests.map(r => (
-          <li key={r._id} className="list-group-item d-flex justify-content-between align-items-center">
-            <span>
+          <li
+            key={r._id}
+            className="list-group-item d-flex justify-content-between align-items-center flex-column flex-md-row"
+          >
+            <span className="mb-2 mb-md-0">
               {r.userId?.firstName} {r.userId?.lastName} - {r.courseId?.title}
             </span>
-            <button
-              className="btn btn-sm btn-success"
-              onClick={() => approve(r._id)}
-            >
-              Approve
-            </button>
+            <div className="d-flex gap-2 align-items-center">
+              {r.slipUrl && (
+                <a
+                  href={r.slipUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-sm btn-outline-secondary"
+                >
+                  View Slip
+                </a>
+              )}
+              <button
+                className="btn btn-sm btn-success"
+                onClick={() => approve(r._id)}
+              >
+                Approve
+              </button>
+            </div>
           </li>
         ))}
       </ul>

--- a/frontend/src/pages/Dashboard/MyClasses.jsx
+++ b/frontend/src/pages/Dashboard/MyClasses.jsx
@@ -140,7 +140,7 @@ const MyClasses = () => {
   const payBank = async (courseId) => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.zip';
+    input.accept = 'image/*';
     input.onchange = async () => {
       const file = input.files[0];
       if (!file) return;

--- a/frontend/src/pages/Dashboard/PaymentHistory.jsx
+++ b/frontend/src/pages/Dashboard/PaymentHistory.jsx
@@ -293,12 +293,12 @@ const PaymentHistory = () => {
                         <span className="detail-value">{formatDate(payment.date)}</span>
                       </div>
 
-                      {payment.type === 'bank' && payment.zipUrl && (
+                      {payment.type === 'bank' && payment.slipUrl && (
                         <div className="detail-row">
                           <span className="detail-label">Slip:</span>
-                          <a 
-                            href={payment.zipUrl} 
-                            target="_blank" 
+                          <a
+                            href={payment.slipUrl}
+                            target="_blank"
                             rel="noopener noreferrer"
                             className="slip-link"
                           >


### PR DESCRIPTION
## Summary
- allow bank payment requests to store `slipUrl` instead of `zipUrl`
- accept jpg/jpeg/png files when uploading a bank slip
- update bank payment controller and frontend pages for new property
- show slip link in admin requests and payment history
- accept image files from dashboard when submitting bank payments

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a0bb07948322a094742846dbbdb4