### PR TITLE
Enable admin bank payment review

### DIFF
--- a/backend/routes/bankPaymentRoutes.js
+++ b/backend/routes/bankPaymentRoutes.js
@@ -6,6 +6,7 @@ const uploadBankSlip = require('../middleware/uploadBankSlip');
 
 router.post('/submit', authenticateToken, uploadBankSlip.single('slip'), controller.submitBankPayment);
 router.put('/approve/:requestId', authenticateToken, requireAdmin, controller.approveBankPayment);
+router.get('/download/:requestId', authenticateToken, requireAdmin, controller.downloadBankSlip);
 router.get('/requests', authenticateToken, requireAdmin, controller.getBankPaymentRequests);
 router.get('/my', authenticateToken, controller.getMyBankPayments);
 

--- a/frontend/src/pages/Admin/BankPaymentRequests.jsx
+++ b/frontend/src/pages/Admin/BankPaymentRequests.jsx
@@ -23,6 +23,21 @@ function BankPaymentRequests() {
     }
   };
 
+  const download = async (id) => {
+    try {
+      const res = await api.get(`/bank-payment/download/${id}`, { responseType: 'blob' });
+      const url = window.URL.createObjectURL(new Blob([res.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', 'slip');
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+    } catch (err) {
+      console.error('Download failed', err);
+    }
+  };
+
   return (
     <div className="container mt-4">
       <h2>Bank Payment Requests</h2>
@@ -37,14 +52,22 @@ function BankPaymentRequests() {
             </span>
             <div className="d-flex gap-2 align-items-center">
               {r.slipUrl && (
-                <a
-                  href={r.slipUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="btn btn-sm btn-outline-secondary"
-                >
-                  View Slip
-                </a>
+                <>
+                  <a
+                    href={r.slipUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-sm btn-outline-secondary"
+                  >
+                    View Slip
+                  </a>
+                  <button
+                    className="btn btn-sm btn-outline-primary"
+                    onClick={() => download(r._id)}
+                  >
+                    Download
+                  </button>
+                </>
               )}
               <button
                 className="btn btn-sm btn-success"

--- a/frontend/src/pages/Dashboard/PendingPayments.jsx
+++ b/frontend/src/pages/Dashboard/PendingPayments.jsx
@@ -41,7 +41,7 @@ const PendingPayments = () => {
   const payBank = async (courseId) => {
     const input = document.createElement('input');
     input.type = 'file';
-    input.accept = '.zip';
+    input.accept = 'image/*';
     input.onchange = async () => {
       const file = input.files[0];
       if (!file) return;


### PR DESCRIPTION
## Summary
- add downloadBankSlip controller
- expose `/download/:requestId` route
- allow admin to download bank slips in dashboard
- accept image uploads for bank deposit form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6872a352a8c88322aacf091e533200a9