### PR TITLE
Add shop order checkout with image upload

### DIFF
--- a/backend/middleware/uploadProductImage.js
+++ b/backend/middleware/uploadProductImage.js
@@ -1,0 +1,38 @@
+const multer = require('multer');
+const path = require('path');
+const fs = require('fs');
+
+const defaultDir = path.join(__dirname, '..', 'uploads', 'products');
+const fallbackDir = '/tmp/uploads/products';
+
+let uploadDir = process.env.UPLOAD_DIR ? path.join(process.env.UPLOAD_DIR, 'products') : defaultDir;
+if (process.env.VERCEL && !process.env.UPLOAD_DIR) {
+  uploadDir = fallbackDir;
+}
+
+try {
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+} catch (err) {
+  uploadDir = fallbackDir;
+  if (!fs.existsSync(uploadDir)) {
+    fs.mkdirSync(uploadDir, { recursive: true });
+  }
+}
+
+const storage = multer.diskStorage({
+  destination: (req, file, cb) => cb(null, uploadDir),
+  filename: (req, file, cb) => {
+    const unique = `${Date.now()}-${file.originalname}`;
+    cb(null, unique);
+  }
+});
+
+const fileFilter = (req, file, cb) => {
+  const allowed = ['.jpg', '.jpeg', '.png', '.gif'];
+  const ext = path.extname(file.originalname).toLowerCase();
+  cb(null, allowed.includes(ext));
+};
+
+module.exports = multer({ storage, fileFilter });

--- a/backend/models/ShopOrder.js
+++ b/backend/models/ShopOrder.js
@@ -1,0 +1,26 @@
+const mongoose = require('mongoose');
+
+const itemSchema = new mongoose.Schema({
+  productId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', required: true },
+  qty: { type: Number, required: true },
+  price: { type: Number, required: true }
+}, { _id: false });
+
+const orderSchema = new mongoose.Schema({
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+  orderId: { type: String, required: true, unique: true },
+  paymentId: { type: String, default: null },
+  items: [itemSchema],
+  total: { type: Number, required: true },
+  status: { type: String, enum: ['pending', 'paid', 'cancelled', 'failed'], default: 'pending' },
+  customer: {
+    firstName: String,
+    lastName: String,
+    email: String,
+    phone: String,
+    address: String,
+    city: String
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('ShopOrder', orderSchema);

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -2,12 +2,15 @@ const express = require('express');
 const router = express.Router();
 const productController = require('../controllers/productController');
 const { authenticateToken, requireAdmin } = require('../middleware/authMiddleware');
+const uploadProductImage = require('../middleware/uploadProductImage');
 
-router.post('/products', authenticateToken, requireAdmin, productController.createProduct);
+router.post('/products', authenticateToken, requireAdmin, uploadProductImage.single('image'), productController.createProduct);
 router.get('/products', productController.getProducts);
 router.get('/products/:id', productController.getProductById);
-router.put('/products/:id', authenticateToken, requireAdmin, productController.updateProduct);
+router.put('/products/:id', authenticateToken, requireAdmin, uploadProductImage.single('image'), productController.updateProduct);
 router.delete('/products/:id', authenticateToken, requireAdmin, productController.deleteProduct);
 router.post('/shop/checkout', authenticateToken, productController.initiateCheckout);
+router.post('/shop/verify', authenticateToken, productController.verifyOrder);
+router.get('/shop/orders', authenticateToken, requireAdmin, productController.getOrders);
 
 module.exports = router;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import AllClasses from './pages/Classes/AllClasses';
 // Shop
 import Shop from './pages/Shop/Shop';
 import Cart from './pages/Shop/Cart';
+import Checkout from './pages/Shop/Checkout';
 
 // Student Dashboard
 import StudentDashboard from './pages/Dashboard/StudentDashboard';
@@ -67,6 +68,7 @@ import CreateNotice from './pages/Admin/CreateNotice';
 import CreateProduct from './pages/Admin/CreateProduct';
 import ProductList from './pages/Admin/ProductList';
 import EditProduct from './pages/Admin/EditProduct';
+import OrderList from './pages/Admin/OrderList';
 import RequireAdmin from './components/RequireAdmin';
 import RequireTeacher from './components/RequireTeacher';
 import RequireAssistant from './components/RequireAssistant';
@@ -96,6 +98,7 @@ function App() {
         {/* Shop */}
         <Route path="/shop" element={<Shop />} />
         <Route path="/shop/cart" element={<Cart />} />
+        <Route path="/shop/checkout" element={<Checkout />} />
 
         {/* Payment return */}
         <Route path="/payment-success" element={<PaymentSuccess />} />
@@ -151,6 +154,7 @@ function App() {
         <Route path="/admin/products" element={<RequireAdmin><ProductList /></RequireAdmin>} />
         <Route path="/admin/products/create" element={<RequireAdmin><CreateProduct /></RequireAdmin>} />
         <Route path="/admin/products/:productId/edit" element={<RequireAdmin><EditProduct /></RequireAdmin>} />
+        <Route path="/admin/orders" element={<RequireAdmin><OrderList /></RequireAdmin>} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/pages/Admin/CreateProduct.jsx
+++ b/frontend/src/pages/Admin/CreateProduct.jsx
@@ -3,19 +3,29 @@ import api from '../../api';
 import { useNavigate } from 'react-router-dom';
 
 const CreateProduct = () => {
-  const [form, setForm] = useState({ name: '', imageUrl: '', price: '', quantity: '' });
+  const [form, setForm] = useState({ name: '', price: '', quantity: '' });
+  const [file, setFile] = useState(null);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
+    const { name, value, files } = e.target;
+    if (name === 'image' && files) {
+      setFile(files[0]);
+    } else {
+      setForm({ ...form, [name]: value });
+    }
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await api.post('/products', form);
+      const fd = new FormData();
+      fd.append('name', form.name);
+      fd.append('price', form.price);
+      fd.append('quantity', form.quantity);
+      if (file) fd.append('image', file);
+      await api.post('/products', fd, { headers: { 'Content-Type': 'multipart/form-data' } });
       setMessage('Product added!');
       setTimeout(() => navigate('/admin/products/create'), 1000);
     } catch (err) {
@@ -38,9 +48,9 @@ const CreateProduct = () => {
         />
         <input
           className="form-control mb-2"
-          name="imageUrl"
-          placeholder="Image URL"
-          value={form.imageUrl}
+          name="image"
+          type="file"
+          accept="image/*"
           onChange={handleChange}
         />
         <input

--- a/frontend/src/pages/Admin/EditProduct.jsx
+++ b/frontend/src/pages/Admin/EditProduct.jsx
@@ -4,7 +4,8 @@ import api from '../../api';
 
 function EditProduct() {
   const { productId } = useParams();
-  const [form, setForm] = useState({ name: '', imageUrl: '', price: '', quantity: '' });
+  const [form, setForm] = useState({ name: '', price: '', quantity: '' });
+  const [file, setFile] = useState(null);
   const [message, setMessage] = useState('');
   const navigate = useNavigate();
 
@@ -12,7 +13,6 @@ function EditProduct() {
     api.get(`/products/${productId}`)
       .then(res => setForm({
         name: res.data.product.name || '',
-        imageUrl: res.data.product.imageUrl || '',
         price: res.data.product.price,
         quantity: res.data.product.quantity || ''
       }))
@@ -20,14 +20,23 @@ function EditProduct() {
   }, [productId, navigate]);
 
   const handleChange = (e) => {
-    const { name, value } = e.target;
-    setForm({ ...form, [name]: value });
+    const { name, value, files } = e.target;
+    if (name === 'image' && files) {
+      setFile(files[0]);
+    } else {
+      setForm({ ...form, [name]: value });
+    }
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await api.put(`/products/${productId}`, form);
+      const fd = new FormData();
+      fd.append('name', form.name);
+      fd.append('price', form.price);
+      fd.append('quantity', form.quantity);
+      if (file) fd.append('image', file);
+      await api.put(`/products/${productId}`, fd, { headers: { 'Content-Type': 'multipart/form-data' } });
       setMessage('Product updated');
       navigate('/admin/products');
     } catch (err) {
@@ -50,9 +59,9 @@ function EditProduct() {
         />
         <input
           className="form-control mb-2"
-          name="imageUrl"
-          placeholder="Image URL"
-          value={form.imageUrl}
+          name="image"
+          type="file"
+          accept="image/*"
           onChange={handleChange}
         />
         <input

--- a/frontend/src/pages/Admin/OrderList.jsx
+++ b/frontend/src/pages/Admin/OrderList.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+
+const OrderList = () => {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    api.get('/shop/orders')
+      .then(res => setOrders(res.data.orders || []))
+      .catch(() => setOrders([]));
+  }, []);
+
+  return (
+    <div className="container mt-4">
+      <h2>Orders</h2>
+      <ul className="list-group">
+        {orders.map(o => (
+          <li key={o._id} className="list-group-item">
+            <div className="fw-semibold">{o.customer?.firstName} {o.customer?.lastName}</div>
+            <div>{o.customer?.address}</div>
+            <div>Status: {o.status}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OrderList;

--- a/frontend/src/pages/PaymentSuccess.jsx
+++ b/frontend/src/pages/PaymentSuccess.jsx
@@ -16,9 +16,15 @@ const PaymentSuccess = () => {
 
     const verify = async () => {
       try {
-        await api.post('/payment/verify-payment', { orderId });
-        setMessage('Payment verified! Redirecting to dashboard...');
-        setTimeout(() => navigate('/dashboard'), 1500);
+        if (orderId.startsWith('SHOP')) {
+          await api.post('/shop/verify', { orderId });
+          setMessage('Order received! Redirecting to shop...');
+          setTimeout(() => navigate('/shop'), 1500);
+        } else {
+          await api.post('/payment/verify-payment', { orderId });
+          setMessage('Payment verified! Redirecting to dashboard...');
+          setTimeout(() => navigate('/dashboard'), 1500);
+        }
       } catch (err) {
         setMessage('Payment verification failed.');
       }

--- a/frontend/src/pages/Shop/Cart.jsx
+++ b/frontend/src/pages/Shop/Cart.jsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react';
-import api from '../../api';
 import './shop.css';
+import { useNavigate } from 'react-router-dom';
 
 const Cart = () => {
   const [items, setItems] = useState([]);
-  const [msg, setMsg] = useState('');
+  const navigate = useNavigate();
 
   useEffect(() => {
     const cart = localStorage.getItem('cart');
@@ -13,32 +13,9 @@ const Cart = () => {
 
   const total = items.reduce((sum, item) => sum + item.price * (item.qty || 1), 0);
 
-  const handleCheckout = async () => {
-    try {
-      const payload = items.map((i) => ({ productId: i._id, qty: i.qty || 1 }));
-      const res = await api.post('/shop/checkout', { items: payload });
-      const data = res.data.paymentData;
-
-      const form = document.createElement('form');
-      form.method = 'POST';
-      form.action = data.sandbox
-        ? 'https://sandbox.payhere.lk/pay/checkout'
-        : 'https://www.payhere.lk/pay/checkout';
-
-      for (const key in data) {
-        const input = document.createElement('input');
-        input.type = 'hidden';
-        input.name = key;
-        input.value = data[key];
-        form.appendChild(input);
-      }
-
-      document.body.appendChild(form);
-      form.submit();
-      form.remove();
-    } catch (err) {
-      setMsg('Checkout failed');
-    }
+  const handleCheckout = () => {
+    if (items.length === 0) return;
+    navigate('/shop/checkout');
   };
 
   const clearCart = () => {

--- a/frontend/src/pages/Shop/Checkout.jsx
+++ b/frontend/src/pages/Shop/Checkout.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../../api';
+
+const Checkout = () => {
+  const [items, setItems] = useState([]);
+  const [customer, setCustomer] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    phone: '',
+    address: '',
+    city: ''
+  });
+  const [msg, setMsg] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const cart = localStorage.getItem('cart');
+    if (cart) setItems(JSON.parse(cart));
+    else navigate('/shop/cart');
+  }, [navigate]);
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setCustomer(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handlePay = async e => {
+    e.preventDefault();
+    try {
+      const payloadItems = items.map(i => ({ productId: i._id, qty: i.qty || 1 }));
+      const res = await api.post('/shop/checkout', { items: payloadItems, customer });
+      const data = res.data.paymentData;
+      const form = document.createElement('form');
+      form.method = 'POST';
+      form.action = data.sandbox
+        ? 'https://sandbox.payhere.lk/pay/checkout'
+        : 'https://www.payhere.lk/pay/checkout';
+      for (const key in data) {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = key;
+        input.value = data[key];
+        form.appendChild(input);
+      }
+      document.body.appendChild(form);
+      form.submit();
+      form.remove();
+    } catch (err) {
+      setMsg('Checkout failed');
+    }
+  };
+
+  return (
+    <div className="container py-4">
+      <h3 className="mb-4 text-center">Checkout</h3>
+      {msg && <p className="text-danger">{msg}</p>}
+      <form onSubmit={handlePay} className="mx-auto" style={{ maxWidth: '500px' }}>
+        <input className="form-control mb-2" name="firstName" placeholder="First name" required value={customer.firstName} onChange={handleChange} />
+        <input className="form-control mb-2" name="lastName" placeholder="Last name" required value={customer.lastName} onChange={handleChange} />
+        <input className="form-control mb-2" name="email" type="email" placeholder="Email" value={customer.email} onChange={handleChange} />
+        <input className="form-control mb-2" name="phone" placeholder="Phone" required value={customer.phone} onChange={handleChange} />
+        <input className="form-control mb-2" name="address" placeholder="Address" required value={customer.address} onChange={handleChange} />
+        <input className="form-control mb-3" name="city" placeholder="City" value={customer.city} onChange={handleChange} />
+        <button className="btn btn-success w-100">Pay</button>
+      </form>
+    </div>
+  );
+};
+
+export default Checkout;


### PR DESCRIPTION
## Summary
- let admins upload product images and store them on the server
- create `ShopOrder` model for product purchases
- implement customer checkout flow with form
- update payment notification to mark shop orders as paid
- allow admins to view orders from dashboard

## Testing
- `npm test` *(fails: jest not installed)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6873041b10a4832297b521b9123ebf45