### PR TITLE
Add cart icon and restrict out-of-stock items

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,7 +1,19 @@
 import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 
 const Navbar = () => {
   const user = JSON.parse(localStorage.getItem('user'));
+  const [cartCount, setCartCount] = useState(0);
+
+  useEffect(() => {
+    const loadCart = () => {
+      const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+      setCartCount(cart.length);
+    };
+    loadCart();
+    window.addEventListener('cartUpdated', loadCart);
+    return () => window.removeEventListener('cartUpdated', loadCart);
+  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem('token');
@@ -13,7 +25,20 @@ const Navbar = () => {
     <nav className="navbar navbar-expand-lg navbar-custom shadow-sm">
       <div className="container">
         <Link className="navbar-brand text-white fw-bold" to="/">LMC</Link>
-        <div className="ms-auto">
+        <div className="ms-auto d-flex align-items-center">
+          {cartCount > 0 && (
+            <Link
+              to="/shop/cart"
+              className="btn btn-sm btn-light position-relative me-3"
+            >
+              🛒
+              <span
+                className="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger"
+              >
+                {cartCount}
+              </span>
+            </Link>
+          )}
           {user ? (
             <button className="btn btn-sm btn-light text-primary" onClick={handleLogout}>
               Logout

--- a/frontend/src/pages/Shop/Cart.jsx
+++ b/frontend/src/pages/Shop/Cart.jsx
@@ -21,6 +21,7 @@ const Cart = () => {
   const clearCart = () => {
     localStorage.removeItem('cart');
     setItems([]);
+    window.dispatchEvent(new Event('cartUpdated'));
   };
 
   return (

--- a/frontend/src/pages/Shop/Shop.jsx
+++ b/frontend/src/pages/Shop/Shop.jsx
@@ -18,9 +18,14 @@ const Shop = () => {
   }, []);
 
   const addToCart = (item) => {
+    if (item.quantity <= 0) {
+      alert('Out of stock');
+      return;
+    }
     const newCart = [...cart, { ...item, qty: 1 }];
     setCart(newCart);
     localStorage.setItem('cart', JSON.stringify(newCart));
+    window.dispatchEvent(new Event('cartUpdated'));
   };
 
   return (
@@ -43,8 +48,9 @@ const Shop = () => {
                 <button
                   className="btn btn-primary mt-auto w-100"
                   onClick={() => addToCart(item)}
+                  disabled={item.quantity <= 0}
                 >
-                  Add to Cart
+                  {item.quantity > 0 ? 'Add to Cart' : 'Out of Stock'}
                 </button>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- show a cart icon in the navbar when items exist
- track cart count via `cartUpdated` events
- prevent adding out-of-stock products and indicate status
- update clear-cart to refresh cart count

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687307ef8e008322a36d3e4834088e23