### PR TITLE
Implement delivery status management

### DIFF
--- a/backend/controllers/productController.js
+++ b/backend/controllers/productController.js
@@ -187,3 +187,19 @@ exports.getOrders = async (req, res) => {
     res.status(500).json({ message: 'Failed to fetch orders' });
   }
 };
+
+exports.updateDeliveryStatus = async (req, res) => {
+  try {
+    const { status } = req.body;
+    const order = await ShopOrder.findByIdAndUpdate(
+      req.params.id,
+      { deliveryStatus: status },
+      { new: true, runValidators: true }
+    );
+    if (!order) return res.status(404).json({ message: 'Order not found' });
+    res.json({ order });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to update status' });
+  }
+};

--- a/backend/models/ShopOrder.js
+++ b/backend/models/ShopOrder.js
@@ -13,6 +13,7 @@ const orderSchema = new mongoose.Schema({
   items: [itemSchema],
   total: { type: Number, required: true },
   status: { type: String, enum: ['pending', 'paid', 'cancelled', 'failed'], default: 'pending' },
+  deliveryStatus: { type: String, enum: ['pending', 'shipped', 'delivered'], default: 'pending' },
   customer: {
     firstName: String,
     lastName: String,

--- a/backend/routes/productRoutes.js
+++ b/backend/routes/productRoutes.js
@@ -12,5 +12,6 @@ router.delete('/products/:id', authenticateToken, requireAdmin, productControlle
 router.post('/shop/checkout', authenticateToken, productController.initiateCheckout);
 router.post('/shop/verify', authenticateToken, productController.verifyOrder);
 router.get('/shop/orders', authenticateToken, requireAdmin, productController.getOrders);
+router.put('/shop/orders/:id', authenticateToken, requireAdmin, productController.updateDeliveryStatus);
 
 module.exports = router;

--- a/frontend/src/pages/Admin/OrderList.jsx
+++ b/frontend/src/pages/Admin/OrderList.jsx
@@ -10,6 +10,15 @@ const OrderList = () => {
       .catch(() => setOrders([]));
   }, []);
 
+  const changeStatus = async (id, status) => {
+    try {
+      await api.put(`/shop/orders/${id}`, { status });
+      setOrders(orders.map(o => o._id === id ? { ...o, deliveryStatus: status } : o));
+    } catch (err) {
+      alert('Update failed');
+    }
+  };
+
   return (
     <div className="container mt-4">
       <h2>Orders</h2>
@@ -18,7 +27,19 @@ const OrderList = () => {
           <li key={o._id} className="list-group-item">
             <div className="fw-semibold">{o.customer?.firstName} {o.customer?.lastName}</div>
             <div>{o.customer?.address}</div>
-            <div>Status: {o.status}</div>
+            <div className="mb-2">Order Status: {o.status}</div>
+            <div className="d-flex align-items-center">
+              <span className="me-2">Delivery:</span>
+              <select
+                className="form-select form-select-sm w-auto"
+                value={o.deliveryStatus || 'pending'}
+                onChange={e => changeStatus(o._id, e.target.value)}
+              >
+                <option value="pending">Pending</option>
+                <option value="shipped">Shipped</option>
+                <option value="delivered">Delivered</option>
+              </select>
+            </div>
           </li>
         ))}
       </ul>


### PR DESCRIPTION
## Summary
- add `deliveryStatus` to order model
- allow admins to update order delivery status
- expose new route to update delivery
- show and edit delivery status on admin order list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730b95aa4483229fbfe598748216ae