### PR TITLE
Add admin orders tile

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -40,6 +40,7 @@ const Home = () => {
             <Tile title="Teachers" icon="🧑‍🏫" link="/admin/teachers" />
             <Tile title="Notices" icon="📢" link="/admin/notices" />
             <Tile title="Products" icon="🛍️" link="/admin/products" />
+            <Tile title="Orders" icon="📦" link="/admin/orders" />
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- show Orders tile on homepage for admins so they can access product delivery UI

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68730d63c1548322bd9e44ffd78f1758