### PR TITLE
Add student ID overlay on course videos

### DIFF
--- a/frontend/src/pages/Classes/ClassDetail.jsx
+++ b/frontend/src/pages/Classes/ClassDetail.jsx
@@ -414,6 +414,18 @@ const ClassDetail = () => {
           border: none;
         }
 
+        .student-id-overlay {
+          position: absolute;
+          top: 8px;
+          right: 8px;
+          background: rgba(0, 0, 0, 0.6);
+          color: #fff;
+          padding: 2px 6px;
+          font-size: 12px;
+          border-radius: 4px;
+          pointer-events: none;
+        }
+
         .video-locked {
           padding: 40px 20px;
           text-align: center;
@@ -650,6 +662,11 @@ const ClassDetail = () => {
                           loading="lazy"
                           allowFullScreen
                         ></iframe>
+                        {user?.phoneNumber && (
+                          <div className="student-id-overlay">
+                            {user.phoneNumber}
+                          </div>
+                        )}
                       </div>
                     ) : (
                       <div className="video-locked">

--- a/frontend/src/pages/Dashboard/Recordings.jsx
+++ b/frontend/src/pages/Dashboard/Recordings.jsx
@@ -193,12 +193,19 @@ function Recordings() {
                   
                   <div className="video-player">
                     {selectedVideo.videoUrl ? (
-                      <iframe
-                        src={selectedVideo.videoUrl}
-                        title={selectedVideo.title}
-                        loading="lazy"
-                        allowFullScreen
-                      ></iframe>
+                      <>
+                        <iframe
+                          src={selectedVideo.videoUrl}
+                          title={selectedVideo.title}
+                          loading="lazy"
+                          allowFullScreen
+                        ></iframe>
+                        {JSON.parse(localStorage.getItem('user') || '{}').phoneNumber && (
+                          <div className="student-id-overlay">
+                            {JSON.parse(localStorage.getItem('user') || '{}').phoneNumber}
+                          </div>
+                        )}
+                      </>
                     ) : (
                       <div className="no-video">
                         <div className="no-video-icon">📹</div>
@@ -496,6 +503,18 @@ const recordingsStyles = `
     width: 100%;
     height: 100%;
     border: none;
+  }
+
+  .student-id-overlay {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    background: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 2px 6px;
+    font-size: 12px;
+    border-radius: 4px;
+    pointer-events: none;
   }
 
   .no-video {


### PR DESCRIPTION
## Summary
- overlay student's phone number at top-right corner of videos in class details page
- show same overlay in the course recordings player

## Testing
- `npm test --prefix backend` *(fails: jest not found)*
- `npm test --prefix frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687621297a208322b225fd3f910d128d