### PR TITLE
Remove assignment download link

### DIFF
--- a/frontend/src/pages/Dashboard/Assignments.jsx
+++ b/frontend/src/pages/Dashboard/Assignments.jsx
@@ -61,8 +61,13 @@ const Assignments = () => {
               <strong>{a.title}</strong>
               {a.description && <p className="mb-1">{a.description}</p>}
               {a.fileUrl && (
-                <a href={a.fileUrl} className="d-block" download>
-                  Download File
+                <a
+                  href={a.fileUrl}
+                  className="d-block"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  View Assignment
                 </a>
               )}
               {sub && (


### PR DESCRIPTION
## Summary
- prevent students from downloading assignment files
- instead open files in a new tab so they can be viewed

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762c0293bc83229100f8fcaf9ca218